### PR TITLE
Sorts asset map paths to replace by length descending.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ function AssetRewrite(inputTree, options) {
   this.prepend = options.prepend || '';
   this.description = options.description;
   this.ignore = options.ignore || []; // files to ignore
+
+  this.assetMapKeys = null;
 }
 
 AssetRewrite.prototype = Object.create(Filter.prototype);
@@ -34,6 +36,10 @@ AssetRewrite.prototype.processAndCacheFile = function (srcDir, destDir, relative
  */
 
 AssetRewrite.prototype.canProcessFile = function(relativePath) {
+  if (!this.assetMapKeys) {
+    this.generateAssetMapKeys();
+  }
+
   if (!this.inverseAssetMap) {
     var inverseAssetMap = {};
     var assetMap = this.assetMap;
@@ -100,7 +106,9 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
 AssetRewrite.prototype.processString = function (string, relativePath) {
   var newString = string;
 
-  for (var key in this.assetMap) {
+  for (var i = 0, keyLength = this.assetMapKeys.length; i < keyLength; i++) {
+    var key = this.assetMapKeys[i];
+
     if (this.assetMap.hasOwnProperty(key)) {
       /*
        * Rewrite absolute URLs
@@ -125,6 +133,24 @@ AssetRewrite.prototype.processString = function (string, relativePath) {
 
   return newString;
 };
+
+AssetRewrite.prototype.generateAssetMapKeys = function () {
+  var keys = Object.keys(this.assetMap);
+
+  keys.sort(function (a, b) {
+    if (a.length < b.length) {
+      return 1;
+    }
+
+    if (a.length > b.length) {
+      return -1;
+    }
+
+    return 0;
+  });
+
+  this.assetMapKeys = keys;
+}
 
 function escapeRegExp(string) {
   return string.replace(/([.*+?^${}()|\[\]\/\\])/g, "\\$1");

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -103,4 +103,23 @@ describe('broccoli-asset-rev', function() {
     });
 
   });
+
+  it('replaces the correct match for the file extension', function () {
+    var sourcePath = 'tests/fixtures/extensions';
+
+    var tree = rewrite(sourcePath + '/input', {
+      assetMap: {
+        'fonts/roboto-regular.eot': 'fonts/roboto-regular-f1.eot',
+        'fonts/roboto-regular.woff': 'fonts/roboto-regular-f3.woff',
+        'fonts/roboto-regular.ttf': 'fonts/roboto-regular-f4.ttf',
+        'fonts/roboto-regular.svg': 'fonts/roboto-regular-f5.svg',
+        'fonts/roboto-regular.woff2': 'fonts/roboto-regular-f2.woff2'
+      }
+    });
+
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
 });

--- a/tests/fixtures/extensions/input/styles.css
+++ b/tests/fixtures/extensions/input/styles.css
@@ -1,0 +1,11 @@
+@font-face {
+  font-family: 'RobotoRegular';
+  src: url('fonts/roboto-regular.eot');
+  src: url('fonts/roboto-regular.eot?#iefix') format('embedded-opentype'),
+    url('fonts/roboto-regular.woff2') format('woff2'),
+    url('fonts/roboto-regular.woff') format('woff'),
+    url('fonts/roboto-regular.ttf') format('truetype'),
+    url('fonts/roboto-regular.svg#robotoregular') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}

--- a/tests/fixtures/extensions/output/styles.css
+++ b/tests/fixtures/extensions/output/styles.css
@@ -1,0 +1,11 @@
+@font-face {
+  font-family: 'RobotoRegular';
+  src: url('fonts/roboto-regular-f1.eot');
+  src: url('fonts/roboto-regular-f1.eot?#iefix') format('embedded-opentype'),
+    url('fonts/roboto-regular-f2.woff2') format('woff2'),
+    url('fonts/roboto-regular-f3.woff') format('woff'),
+    url('fonts/roboto-regular-f4.ttf') format('truetype'),
+    url('fonts/roboto-regular-f5.svg#robotoregular') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}


### PR DESCRIPTION
This addresses the issue from https://github.com/rickharrison/broccoli-asset-rev/issues/28

If a file has the same name, but with 2 different extensions, it is possible that the shorter extension will replace the longer one. I.E. a file with the extension `woff` will replace the source of `woff2`. To fix this, the plugin will now sort by the asset map length so that longer extensions are always replaced first.
