### PR TITLE
Always use matched path for replacement path

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,15 +109,14 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
   var ignoreLibraryCode = new RegExp('(%22|%27|%5C|%28|%29|%3D)[^"\'\\(\\)=]*' + escapeRegExp(assetPath));
 
   while (match = re.exec(newString)) {
-    var replaceString = '';
     if (ignoreLibraryCode.exec(match[1])) {
       continue;
     }
 
+    var replaceString = match[1].replace(assetPath, replacementPath);
+
     if (this.prepend && this.prepend !== '') {
-      replaceString = this.prepend + replacementPath;
-    } else {
-      replaceString = match[1].replace(assetPath, replacementPath);
+      replaceString = this.prepend + replaceString;
     }
 
     newString = newString.replace(new RegExp(escapeRegExp(match[1]), 'g'), replaceString);

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -105,6 +105,22 @@ describe('broccoli-asset-rev', function() {
 
   });
 
+  it('rewrites svgs with prepend', function () {
+    var sourcePath = 'tests/fixtures/svgs-prepend';
+    var tree = rewrite(sourcePath + '/input', {
+      extensions: ['svg'],
+      assetMap: {
+        'icons.svg': 'icons-fingerprint.svg'
+      },
+      prepend: 'https://cloudfront.net/'
+    });
+
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
+
   it('replaces the correct match for the file extension', function () {
     var sourcePath = 'tests/fixtures/extensions';
 

--- a/tests/fixtures/svgs-prepend/input/svg-tag.html
+++ b/tests/fixtures/svgs-prepend/input/svg-tag.html
@@ -1,0 +1,1 @@
+<svg><use xlink:href="icons.svg#my-icon-name"></use></svg>

--- a/tests/fixtures/svgs-prepend/output/svg-tag.html
+++ b/tests/fixtures/svgs-prepend/output/svg-tag.html
@@ -1,0 +1,1 @@
+<svg><use xlink:href="https://cloudfront.net/icons-fingerprint.svg#my-icon-name"></use></svg>


### PR DESCRIPTION
This fixes a bug where a hash in an SVG tag would be removed when using
the prepend option, because only the replacement path, but not the full
match with the hash, would be used (see
https://github.com/rickharrison/broccoli-asset-rev/issues/51).