### PR TITLE
Make asset match regex more strict for cases where filename occurs multiple times in project and is suffixed onto cdn url

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
    * ["\'\\(=]{1} - Match one of "'(= exactly one time
    * \\s* - Any amount of white space
    * ( - Starts the first pattern match
-   * [^"\'\\(\\)=]* - Do not match any of ^"'()= 0 or more times
+   * (?:\.\/)? - ignore ./ if it is at the beginning of the path
    * /([.*+?^=!:${}()|\[\]\/\\])/g - Replace .*+?^=!:${}()|[]/\ in filenames with an escaped version for an exact name match
    * [^"\'\\(\\)\\\\>=]* - Do not match any of ^"'()\>= 0 or more times - Explicitly add \ here because of handlebars compilation
    * ) - End first pattern match
@@ -100,7 +100,7 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
    * ["\'\\)> ]{1} - Match one of "'( > exactly one time
    */
 
-  var re = new RegExp('["\'\\(=]{1}\\s*([^"\'\\(\\)=]*' + escapeRegExp(assetPath) + '[^"\'\\(\\)\\\\>=]*)\\s*[\\\\]*\\s*["\'\\)> ]{1}', 'g');
+  var re = new RegExp('["\'\\(=]{1}\\s*((?:\.\/)?' + escapeRegExp(assetPath) + '[^"\'\\(\\)\\\\>=]*)\\s*[\\\\]*\\s*["\'\\)> ]{1}', 'g');
   var match = null;
   /*
    * This is to ignore matches that should not be changed

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -156,4 +156,21 @@ describe('broccoli-asset-rev', function() {
       confirmOutput(graph.directory, sourcePath + '/output');
     });
   });
+
+  it('replaces similar named assets in nested directories', function () {
+    var sourcePath = 'tests/fixtures/duplicate-filenames';
+
+    var tree = rewrite(sourcePath + '/input', {
+      replaceExtensions: ['html'],
+      assetMap: {
+        'script.js' : 'foo/script.js',
+        'another-dir/script.js' : 'bar/script.js'
+      },
+      prepend: 'https://mycdn.com/'
+    });
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
 });

--- a/tests/fixtures/duplicate-filenames/input/another-dir/another-index.html
+++ b/tests/fixtures/duplicate-filenames/input/another-dir/another-index.html
@@ -1,0 +1,1 @@
+<script src="script.js"></script>

--- a/tests/fixtures/duplicate-filenames/input/index.html
+++ b/tests/fixtures/duplicate-filenames/input/index.html
@@ -1,0 +1,1 @@
+<script src="script.js"></script>

--- a/tests/fixtures/duplicate-filenames/output/another-dir/another-index.html
+++ b/tests/fixtures/duplicate-filenames/output/another-dir/another-index.html
@@ -1,0 +1,1 @@
+<script src="https://mycdn.com/bar/script.js"></script>

--- a/tests/fixtures/duplicate-filenames/output/index.html
+++ b/tests/fixtures/duplicate-filenames/output/index.html
@@ -1,0 +1,1 @@
+<script src="https://mycdn.com/foo/script.js"></script>


### PR DESCRIPTION
Hi,

The CDN we use puts the unique part of the url in the path before the assets filename, so `myasset.jpg` when uploaded becomes `http://mycdn.com/f00b4rXy/myasset.jpg`

This becomes an issue when we have an asset in the root of the dist folder with the same name as an asset in a sub directory.

Basically when `rewriteAssetPath` get's called with arguments like:

```javascript
// string - '<img src="http://mycdn.com/f00b4rXy/myasset.jpg">' (Already revved correctly with the asset in the sub directory)
// assetPath - 'myasset.jpg' (The asset in the root directory)
// replacementPath - 'http://mycdn.com/bazQuxAbc/myasset.jpg' (The revved asset name in the root directory)
AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replacementPath) {
```

This section of the regex: `[^"\'\\(\\)=]*` (https://github.com/rickharrison/broccoli-asset-rewrite/blob/master/index.js#L93) matches `http://mycdn.com/f00b4rXy/` and the string gets revved again to the wrong url (the one for the root `myasset.jpg` rather than the `sub-directory/myasset.js`)

Apologies for the convoluted explanation - it may be easier just to look at the test case in this PR.

Looking at that regex, it looks to me that the only reason for this section `[^"\'\\(\\)=]*` is to ignore the `./` at the beginning of a row, so `./assets/script.js` gets replaced by the replacement for `assets/script.js`

If this is the case, this PR proposes that the match is more specific and we explicitly ignore this case instead `(?:\.\/)?`

Let me know if I've missed any other use cases for that rule in the regex.

