### PR TITLE
[Failed test] when the new value contains the original value

### DIFF
--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -36,6 +36,7 @@ describe('broccoli-asset-rev', function() {
     var tree = rewrite(sourcePath + '/input', {
       assetMap: {
         'foo/bar/widget.js': 'blahzorz-1.js',
+        'img.png': 'fingerprinted-img.png',
         'images/sample.png': 'images/fingerprinted-sample.png',
         'fonts/OpenSans/Light/OpenSans-Light.eot': 'fonts/OpenSans/Light/fingerprinted-OpenSans-Light.eot',
         'fonts/OpenSans/Light/OpenSans-Light.woff': 'fonts/OpenSans/Light/fingerprinted-OpenSans-Light.woff',

--- a/tests/fixtures/basic/input/url-no-prefix.css
+++ b/tests/fixtures/basic/input/url-no-prefix.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url('img.png')}

--- a/tests/fixtures/basic/output/url-no-prefix.css
+++ b/tests/fixtures/basic/output/url-no-prefix.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url('fingerprinted-img.png')}


### PR DESCRIPTION
broccoli-asset-rewrite is configured to replace `img.png` with `fingerprinted-img.png`:
```
assetMap: {
  'img.png': 'fingerprinted-img.png'
}
```

When run against this css,
```
.sample-img{width:50px;height:50px;background-image:url('img.png')}
```

the expected output is
```
.sample-img{width:50px;height:50px;background-image:url('fingerprinted-img.png')}
```

but the actual output is
```
.sample-img{width:50px;height:50px;background-image:url('fingerprinted-fingerprinted-img.png')}
```

Test results:
```
  6 passing (84ms)
  1 failing

  1) broccoli-asset-rev uses the provided assetMap to replace strings:

      AssertionError: url-no-prefix.css: does not match expected output
      + expected - actual

      +.sample-img{width:50px;height:50px;background-image:url('fingerprinted-img.png')}
      -.sample-img{width:50px;height:50px;background-image:url('fingerprinted-fingerprinted-img.png')}
```

This happens because `fingerprinted-img.png` contains the original string `img.png`. The solution is to ensure that we don't process the same value twice, i.e. only move forward through the file