### PR TITLE
Add support for common `annotation` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ var assetNode = new AssetRewrite(node, {
   - `replaceExtensions` - Default: `['html', 'css']` - The file types to replace source code with new checksum file names.
   - `prepend` - Default: `''` - A string to prepend to all of the assets. Useful for CDN urls like `https://subdomain.cloudfront.net/`
   - `ignore` - Default: `[]` - Ignore files from being rewritten.
+  - `annotation` - Default: null - A human-readable description for this plugin instance.

--- a/index.js
+++ b/index.js
@@ -22,13 +22,15 @@ function AssetRewrite(inputNode, options) {
   }
 
   options = options || {};
-  options.extensions = options.replaceExtensions || ['html', 'css'];
 
-  Filter.call(this, inputNode, options);
+  Filter.call(this, inputNode, {
+    extensions: options.replaceExtensions || ['html', 'css'],
+    // We should drop support for `description` in the next major release
+    annotation: options.description || options.annotation
+  });
 
   this.assetMap = options.assetMap || {};
   this.prepend = options.prepend || '';
-  this.description = options.description;
   this.ignore = options.ignore || []; // files to ignore
 
   this.assetMapKeys = null;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/rickharrison/broccoli-asset-rewrite",
   "dependencies": {
-    "broccoli-filter": "^0.2.0"
+    "broccoli-filter": "^1.1.0"
   },
   "devDependencies": {
     "mocha": "~1.20.1",


### PR DESCRIPTION
Also fix handling of `description` option after recent broccoli-filter update.
Filter (via Plugin) automatically sets `this.description` in .read
compatibility mode, so we don't need to set it.
