### PR TITLE
Fix prepend replacements with absolute URLs and fragments

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,10 +115,11 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
       continue;
     }
 
+    replaceString = match[1].replace(assetPath, replacementPath);
+
     if (this.prepend && this.prepend !== '') {
-      replaceString = this.prepend + replacementPath;
-    } else {
-      replaceString = match[1].replace(assetPath, replacementPath);
+      var removeLeadingSlashRegex = new RegExp('^/?(.*)$');
+      replaceString = this.prepend + removeLeadingSlashRegex.exec(replaceString)[1];
     }
 
     newString = newString.replace(new RegExp(escapeRegExp(match[1]), 'g'), replaceString);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/rickharrison/broccoli-asset-rewrite",
   "dependencies": {
-    "broccoli-filter": "^1.1.0"
+    "broccoli-filter": "~1.1.0"
   },
   "devDependencies": {
     "mocha": "~1.20.1",

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -156,4 +156,48 @@ describe('broccoli-asset-rev', function() {
       confirmOutput(graph.directory, sourcePath + '/output');
     });
   });
+
+  it('maintains fragments', function () {
+    var sourcePath = 'tests/fixtures/fragments';
+    var node = new AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        'images/defs.svg': 'images/fingerprinted-defs.svg'
+      }
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
+
+  it('maintains fragments with prepend', function () {
+    var sourcePath = 'tests/fixtures/fragments-prepend';
+    var node = new AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        'images/defs.svg': 'images/fingerprinted-defs.svg'
+      },
+      prepend: 'https://cloudfront.net/'
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
+
+  it('replaces absolute URLs with prepend', function () {
+    var sourcePath = 'tests/fixtures/absolute-prepend';
+    var node = new AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        'my-image.png': 'my-image-fingerprinted.png'
+      },
+      prepend: 'https://cloudfront.net/'
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
 });

--- a/tests/fixtures/absolute-prepend/input/img-tag.html
+++ b/tests/fixtures/absolute-prepend/input/img-tag.html
@@ -1,0 +1,1 @@
+<img src="/my-image.png">

--- a/tests/fixtures/absolute-prepend/input/unquoted-url-in-styles.css
+++ b/tests/fixtures/absolute-prepend/input/unquoted-url-in-styles.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url(/my-image.png)}

--- a/tests/fixtures/absolute-prepend/output/img-tag.html
+++ b/tests/fixtures/absolute-prepend/output/img-tag.html
@@ -1,0 +1,1 @@
+<img src="https://cloudfront.net/my-image-fingerprinted.png">

--- a/tests/fixtures/absolute-prepend/output/unquoted-url-in-styles.css
+++ b/tests/fixtures/absolute-prepend/output/unquoted-url-in-styles.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url(https://cloudfront.net/my-image-fingerprinted.png)}

--- a/tests/fixtures/fragments-prepend/input/svg-tag.html
+++ b/tests/fixtures/fragments-prepend/input/svg-tag.html
@@ -1,0 +1,1 @@
+<svg><use xlink:href="/images/defs.svg#plus"></use></svg>

--- a/tests/fixtures/fragments-prepend/input/unquoted-url-in-styles.css
+++ b/tests/fixtures/fragments-prepend/input/unquoted-url-in-styles.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url(/images/defs.svg#plus)}

--- a/tests/fixtures/fragments-prepend/output/svg-tag.html
+++ b/tests/fixtures/fragments-prepend/output/svg-tag.html
@@ -1,0 +1,1 @@
+<svg><use xlink:href="https://cloudfront.net/images/fingerprinted-defs.svg#plus"></use></svg>

--- a/tests/fixtures/fragments-prepend/output/unquoted-url-in-styles.css
+++ b/tests/fixtures/fragments-prepend/output/unquoted-url-in-styles.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url(https://cloudfront.net/images/fingerprinted-defs.svg#plus)}

--- a/tests/fixtures/fragments/input/svg-tag.html
+++ b/tests/fixtures/fragments/input/svg-tag.html
@@ -1,0 +1,1 @@
+<svg><use xlink:href="/images/defs.svg#plus"></use></svg>

--- a/tests/fixtures/fragments/input/unquoted-url-in-styles.css
+++ b/tests/fixtures/fragments/input/unquoted-url-in-styles.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url(/images/defs.svg#plus)}

--- a/tests/fixtures/fragments/output/svg-tag.html
+++ b/tests/fixtures/fragments/output/svg-tag.html
@@ -1,0 +1,1 @@
+<svg><use xlink:href="/images/fingerprinted-defs.svg#plus"></use></svg>

--- a/tests/fixtures/fragments/output/unquoted-url-in-styles.css
+++ b/tests/fixtures/fragments/output/unquoted-url-in-styles.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url(/images/fingerprinted-defs.svg#plus)}


### PR DESCRIPTION
The code that was executed when the `prepend` option is present differed
from the normal replacement code, in that it just used the replacement
path. Also, absolute URLs with the `prepend` option would have 2 slashes

Closes #25 