### PR TITLE
Rewrite the replacer to operate in a single pass

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,12 +39,6 @@ function AssetRewrite(inputNode, options) {
 AssetRewrite.prototype = Object.create(Filter.prototype);
 AssetRewrite.prototype.constructor = AssetRewrite;
 
-AssetRewrite.prototype.processAndCacheFile = function (srcDir, destDir, relativePath) {
-  this._cache = {};
-
-  return Filter.prototype.processAndCacheFile.apply(this, arguments);
-}
-
 /**
  * Checks that file is not being ignored and destination doesn't already have a file
  * @param relativePath

--- a/index.js
+++ b/index.js
@@ -46,10 +46,6 @@ AssetRewrite.prototype.constructor = AssetRewrite;
  */
 
 AssetRewrite.prototype.canProcessFile = function(relativePath) {
-  if (!this.assetMapKeys) {
-    this.generateAssetMapKeys();
-  }
-
   if (!this.inverseAssetMap) {
     var inverseAssetMap = {};
     var assetMap = this.assetMap;
@@ -74,8 +70,26 @@ AssetRewrite.prototype.canProcessFile = function(relativePath) {
   return Filter.prototype.canProcessFile.apply(this, arguments);
 }
 
-AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replacementPath) {
-  var newString = string;
+AssetRewrite.prototype.processString = function (string, relativePath) {
+  var prepend = this.prepend;
+  var absMap = this.assetMap;
+  var absKeys = this.getAssetMapKeys();
+
+  var relMap = {};
+  var relKeys = absKeys.map(function(path) {
+    var relPath = relative(relativePath, path).replace(/^\.\//, "");
+
+    var relReplacement = relative(relativePath, absMap[path]).replace(/^\.\//, "");
+    if (prepend && prepend !== '') {
+      relReplacement = absMap[path];
+    }
+
+    relMap[relPath] = relReplacement;
+
+    return relPath
+  });
+
+  var assetGroup = '(' + absKeys.concat(relKeys).map(function(p) { return escapeRegExp(p); }).join('|') + ')';
 
   /*
    * Replace all of the assets with their new fingerprint name
@@ -94,71 +108,39 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
    * \\s* - Any amount of white space
    * ["\'\\)> ]{1} - Match one of "'( > exactly one time
    */
+  var assetRE = new RegExp('["\'\\(=]{1}\\s*([^"\'\\(\\)=]*' + assetGroup + '[^"\'\\(\\)\\\\>=]*)\\s*[\\\\]*\\s*["\'\\)> ]{1}', 'g');
 
-  var re = new RegExp('["\'\\(=]{1}\\s*([^"\'\\(\\)=]*' + escapeRegExp(assetPath) + '[^"\'\\(\\)\\\\>=]*)\\s*[\\\\]*\\s*["\'\\)> ]{1}', 'g');
-  var match = null;
+  var sourceMapRE = new RegExp('sourceMappingURL=(' + assetGroup + ')');
+
   /*
    * This is to ignore matches that should not be changed
    * Any URL encoded match that would be ignored above will be ignored by this: "'()=\
    */
-  var ignoreLibraryCode = new RegExp('(%22|%27|%5C|%28|%29|%3D)[^"\'\\(\\)=]*' + escapeRegExp(assetPath));
+  var ignoreLibraryCode = new RegExp('(%22|%27|%5C|%28|%29|%3D)[^"\'\\(\\)=]*' + assetGroup);
 
-  while (match = re.exec(newString)) {
-    var replaceString = '';
-    if (ignoreLibraryCode.exec(match[1])) {
-      continue;
+  /*
+   * This is to detect protocol-relative and absolute URLs.
+   * These URLs will not have anything prepended.
+   */
+  var fullURL = new RegExp('^([a-z][a-z0-9+\\-\\.]*)?://', 'i');
+
+  var replacer = function(wholeMatch, found, assetPath) {
+    if (ignoreLibraryCode.exec(found)) {
+      return wholeMatch;
     }
 
-    if (this.prepend && this.prepend !== '') {
-      replaceString = this.prepend + replacementPath;
-    } else {
-      replaceString = match[1].replace(assetPath, replacementPath);
+    var replacement = absMap[assetPath] || relMap[assetPath];
+    if (prepend && prepend !== '' && !fullURL.exec(found)) {
+      replacement = prepend + replacement;
     }
 
-    newString = newString.replace(new RegExp(escapeRegExp(match[1]), 'g'), replaceString);
-  }
-  var self = this;
-  return newString.replace(new RegExp('sourceMappingURL=' + escapeRegExp(assetPath)), function(wholeMatch) {
-    var replaceString = replacementPath;
-    if (self.prepend && self.prepend !== '' && (!/^sourceMappingURL=(http|https|\/\/)/.test(wholeMatch))) {
-      replaceString = self.prepend + replacementPath;
-    }
-    return wholeMatch.replace(assetPath, replaceString);
-  });
+    return wholeMatch.replace(assetPath, replacement);
+  };
+
+  return string.replace(assetRE, replacer).replace(sourceMapRE, replacer);
 };
 
-AssetRewrite.prototype.processString = function (string, relativePath) {
-  var newString = string;
-
-  for (var i = 0, keyLength = this.assetMapKeys.length; i < keyLength; i++) {
-    var key = this.assetMapKeys[i];
-
-    if (this.assetMap.hasOwnProperty(key)) {
-      /*
-       * Rewrite absolute URLs
-       */
-
-      newString = this.rewriteAssetPath(newString, key, this.assetMap[key]);
-
-      /*
-       * Rewrite relative URLs. If there is a prepend, use the full absolute path.
-       */
-
-      var pathDiff = relative(relativePath, key).replace(/^\.\//, "");
-      var replacementDiff = relative(relativePath, this.assetMap[key]).replace(/^\.\//, "");
-
-      if (this.prepend && this.prepend !== '') {
-        replacementDiff = this.assetMap[key];
-      }
-
-      newString = this.rewriteAssetPath(newString, pathDiff, replacementDiff);
-    }
-  }
-
-  return newString;
-};
-
-AssetRewrite.prototype.generateAssetMapKeys = function () {
+AssetRewrite.prototype.getAssetMapKeys = function () {
   var keys = Object.keys(this.assetMap);
 
   keys.sort(function (a, b) {
@@ -173,7 +155,7 @@ AssetRewrite.prototype.generateAssetMapKeys = function () {
     return 0;
   });
 
-  this.assetMapKeys = keys;
+  return keys;
 };
 
 function escapeRegExp(string) {

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -36,6 +36,7 @@ describe('broccoli-asset-rev', function() {
     var node = new AssetRewrite(sourcePath + '/input', {
       assetMap: {
         'foo/bar/widget.js': 'blahzorz-1.js',
+        'foo/bar/widget-other.js': 'foo/bar/widget.js-other',
         'images/sample.png': 'images/fingerprinted-sample.png',
         'fonts/OpenSans/Light/OpenSans-Light.eot': 'fonts/OpenSans/Light/fingerprinted-OpenSans-Light.eot',
         'fonts/OpenSans/Light/OpenSans-Light.woff': 'fonts/OpenSans/Light/fingerprinted-OpenSans-Light.woff',

--- a/tests/fixtures/basic/input/quoted-script-tag.html
+++ b/tests/fixtures/basic/input/quoted-script-tag.html
@@ -1,1 +1,2 @@
 <script src="foo/bar/widget.js"></script>
+<script src="foo/bar/widget-other.js"></script>

--- a/tests/fixtures/basic/output/quoted-script-tag.html
+++ b/tests/fixtures/basic/output/quoted-script-tag.html
@@ -1,1 +1,2 @@
 <script src="blahzorz-1.js"></script>
+<script src="foo/bar/widget.js-other"></script>


### PR DESCRIPTION
Currently the replacement algorithm makes many passes over the input which results in unwanted replacement when the output of one mapping contains the input of another as a substring. For example, `{'main.css': 'main-fp1.css', 'main.css.map': 'main.css-fp2.map'}` rewrites 'main.css.map' to 'main-fp1.css-fp2.map'.

This implements a new replacement algorithm that operates in a single pass for all paths simultaneously. One additional semantic change is that absolute and protocol-relative URLs will no longer have anything prepended. This generalizes the behavior from sourcemap replacement and I believe is consistent with the intended usage of this library.

Finally, 80db0db fixes compatibility with the latest version of broccoli-filter.