### PR TITLE
Fix prepend replacements with absolute URLs and fragments

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,10 +116,11 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
       continue;
     }
 
+    replaceString = match[1].replace(assetPath, replacementPath);
+
     if (this.prepend && this.prepend !== '') {
-      replaceString = this.prepend + replacementPath;
-    } else {
-      replaceString = match[1].replace(assetPath, replacementPath);
+      var removeLeadingSlashRegex = new RegExp('^/?(.*)$');
+      replaceString = this.prepend + removeLeadingSlashRegex.exec(replaceString)[1];
     }
 
     newString = newString.replace(new RegExp(escapeRegExp(match[1]), 'g'), replaceString);

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
 
     replaceString = match[1].replace(assetPath, replacementPath);
 
-    if (this.prepend && this.prepend !== '') {
+    if (this.prepend && replaceString.indexOf(this.prepend) !== 0) {
       var removeLeadingSlashRegex = new RegExp('^/?(.*)$');
       replaceString = this.prepend + removeLeadingSlashRegex.exec(replaceString)[1];
     }
@@ -128,7 +128,7 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
   var self = this;
   return newString.replace(new RegExp('sourceMappingURL=' + escapeRegExp(assetPath)), function(wholeMatch) {
     var replaceString = replacementPath;
-    if (self.prepend && self.prepend !== '' && (!/^sourceMappingURL=(http|https|\/\/)/.test(wholeMatch))) {
+    if (self.prepend && (!/^sourceMappingURL=(http|https|\/\/)/.test(wholeMatch))) {
       replaceString = self.prepend + replacementPath;
     }
     return wholeMatch.replace(assetPath, replaceString);

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -92,6 +92,7 @@ describe('broccoli-asset-rev', function() {
     var node = new AssetRewrite(sourcePath + '/input', {
       assetMap: {
         'foo/bar/widget.js': 'blahzorz-1.js',
+        'dont/fingerprint/me.js': 'dont/fingerprint/me.js',
         'images/sample.png': 'images/fingerprinted-sample.png',
         'assets/images/foobar.png': 'assets/images/foobar-fingerprint.png'
       },
@@ -190,7 +191,8 @@ describe('broccoli-asset-rev', function() {
     var sourcePath = 'tests/fixtures/absolute-prepend';
     var node = new AssetRewrite(sourcePath + '/input', {
       assetMap: {
-        'my-image.png': 'my-image-fingerprinted.png'
+        'my-image.png': 'my-image-fingerprinted.png',
+        'dont/fingerprint/me.js': 'dont/fingerprint/me.js'
       },
       prepend: 'https://cloudfront.net/'
     });

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -156,4 +156,48 @@ describe('broccoli-asset-rev', function() {
       confirmOutput(graph.directory, sourcePath + '/output');
     });
   });
+
+  it('maintains fragments', function () {
+    var sourcePath = 'tests/fixtures/fragments';
+    var node = new AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        'images/defs.svg': 'images/fingerprinted-defs.svg'
+      }
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
+
+  it('maintains fragments with prepend', function () {
+    var sourcePath = 'tests/fixtures/fragments-prepend';
+    var node = new AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        'images/defs.svg': 'images/fingerprinted-defs.svg'
+      },
+      prepend: 'https://cloudfront.net/'
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
+
+  it('replaces absolute URLs with prepend', function () {
+    var sourcePath = 'tests/fixtures/absolute-prepend';
+    var node = new AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        'my-image.png': 'my-image-fingerprinted.png'
+      },
+      prepend: 'https://cloudfront.net/'
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
 });

--- a/tests/fixtures/absolute-prepend/input/img-tag.html
+++ b/tests/fixtures/absolute-prepend/input/img-tag.html
@@ -1,0 +1,1 @@
+<img src="/my-image.png">

--- a/tests/fixtures/absolute-prepend/input/no-fingerprint.html
+++ b/tests/fixtures/absolute-prepend/input/no-fingerprint.html
@@ -1,0 +1,1 @@
+<script src="dont/fingerprint/me.js"></script>

--- a/tests/fixtures/absolute-prepend/input/unquoted-url-in-styles.css
+++ b/tests/fixtures/absolute-prepend/input/unquoted-url-in-styles.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url(/my-image.png)}

--- a/tests/fixtures/absolute-prepend/output/img-tag.html
+++ b/tests/fixtures/absolute-prepend/output/img-tag.html
@@ -1,0 +1,1 @@
+<img src="https://cloudfront.net/my-image-fingerprinted.png">

--- a/tests/fixtures/absolute-prepend/output/no-fingerprint.html
+++ b/tests/fixtures/absolute-prepend/output/no-fingerprint.html
@@ -1,0 +1,1 @@
+<script src="https://cloudfront.net/dont/fingerprint/me.js"></script>

--- a/tests/fixtures/absolute-prepend/output/unquoted-url-in-styles.css
+++ b/tests/fixtures/absolute-prepend/output/unquoted-url-in-styles.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url(https://cloudfront.net/my-image-fingerprinted.png)}

--- a/tests/fixtures/fragments-prepend/input/svg-tag.html
+++ b/tests/fixtures/fragments-prepend/input/svg-tag.html
@@ -1,0 +1,1 @@
+<svg><use xlink:href="/images/defs.svg#plus"></use></svg>

--- a/tests/fixtures/fragments-prepend/input/unquoted-url-in-styles.css
+++ b/tests/fixtures/fragments-prepend/input/unquoted-url-in-styles.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url(/images/defs.svg#plus)}

--- a/tests/fixtures/fragments-prepend/output/svg-tag.html
+++ b/tests/fixtures/fragments-prepend/output/svg-tag.html
@@ -1,0 +1,1 @@
+<svg><use xlink:href="https://cloudfront.net/images/fingerprinted-defs.svg#plus"></use></svg>

--- a/tests/fixtures/fragments-prepend/output/unquoted-url-in-styles.css
+++ b/tests/fixtures/fragments-prepend/output/unquoted-url-in-styles.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url(https://cloudfront.net/images/fingerprinted-defs.svg#plus)}

--- a/tests/fixtures/fragments/input/svg-tag.html
+++ b/tests/fixtures/fragments/input/svg-tag.html
@@ -1,0 +1,1 @@
+<svg><use xlink:href="/images/defs.svg#plus"></use></svg>

--- a/tests/fixtures/fragments/input/unquoted-url-in-styles.css
+++ b/tests/fixtures/fragments/input/unquoted-url-in-styles.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url(/images/defs.svg#plus)}

--- a/tests/fixtures/fragments/output/svg-tag.html
+++ b/tests/fixtures/fragments/output/svg-tag.html
@@ -1,0 +1,1 @@
+<svg><use xlink:href="/images/fingerprinted-defs.svg#plus"></use></svg>

--- a/tests/fixtures/fragments/output/unquoted-url-in-styles.css
+++ b/tests/fixtures/fragments/output/unquoted-url-in-styles.css
@@ -1,0 +1,1 @@
+.sample-img{width:50px;height:50px;background-image:url(/images/fingerprinted-defs.svg#plus)}

--- a/tests/fixtures/relative-urls-prepend/input/assets/no-fingerprint.html
+++ b/tests/fixtures/relative-urls-prepend/input/assets/no-fingerprint.html
@@ -1,0 +1,1 @@
+<script src="dont/fingerprint/me.js"></script>

--- a/tests/fixtures/relative-urls-prepend/output/assets/no-fingerprint.html
+++ b/tests/fixtures/relative-urls-prepend/output/assets/no-fingerprint.html
@@ -1,0 +1,1 @@
+<script src="https://cloudfront.net/dont/fingerprint/me.js"></script>


### PR DESCRIPTION
This fix for this has been made twice and reverted twice. This reapplies the latter fix, @danmcclain's from #26. It also fixes the double prepend bug from rickharrison/broccoli-asset-rev#87, which inspired #26's revert. [This comment](https://github.com/rickharrison/broccoli-asset-rewrite/issues/25#issuecomment-203598392) hinted that reapplying the old fix was fine, as long as it passed all tests since then, here and in [broccoli-asset-rev](https://github.com/rickharrison/broccoli-asset-rev).

Closes the following:

* rickharrison/broccoli-asset-rev#51
* rickharrison/broccoli-asset-rev#87
* rickharrison/broccoli-asset-rewrite#25

## Test Plan

* Reapply #26's tests.
* Add prepending absolute assets fixtures, which trigger the double prepend bug in this repo (broccoli-asset-rev's test suite already reproduced the bug).
* Add prepending relative assets fixtures, for completeness.