### PR TITLE
Remove relative segments when prepending

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,8 +119,8 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
     replaceString = match[1].replace(assetPath, replacementPath);
 
     if (this.prepend && replaceString.indexOf(this.prepend) !== 0) {
-      var removeLeadingSlashRegex = new RegExp('^/?(.*)$');
-      replaceString = this.prepend + removeLeadingSlashRegex.exec(replaceString)[1];
+      var removeLeadingRelativeOrSlashRegex = new RegExp('^(\\.*/)*(.*)$');
+      replaceString = this.prepend + removeLeadingRelativeOrSlashRegex.exec(replaceString)[2];
     }
 
     newString = newString.replace(new RegExp(escapeRegExp(match[1]), 'g'), replaceString);

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -94,7 +94,8 @@ describe('broccoli-asset-rev', function() {
         'foo/bar/widget.js': 'blahzorz-1.js',
         'dont/fingerprint/me.js': 'dont/fingerprint/me.js',
         'images/sample.png': 'images/fingerprinted-sample.png',
-        'assets/images/foobar.png': 'assets/images/foobar-fingerprint.png'
+        'assets/images/foobar.png': 'assets/images/foobar-fingerprint.png',
+        'img/saturation.png': 'assets/img/saturation-fingerprint.png'
       },
       prepend: 'https://cloudfront.net/'
     });

--- a/tests/fixtures/relative-urls-prepend/input/assets/url-in-styles.css
+++ b/tests/fixtures/relative-urls-prepend/input/assets/url-in-styles.css
@@ -1,1 +1,3 @@
 .sample-img{width:50px;height:50px;background-image:url('images/foobar.png')}
+
+.sample-img2{width:50px;height:50px;background-image:url('../img/saturation.png')}

--- a/tests/fixtures/relative-urls-prepend/output/assets/url-in-styles.css
+++ b/tests/fixtures/relative-urls-prepend/output/assets/url-in-styles.css
@@ -1,1 +1,3 @@
 .sample-img{width:50px;height:50px;background-image:url('https://cloudfront.net/assets/images/foobar-fingerprint.png')}
+
+.sample-img2{width:50px;height:50px;background-image:url('https://cloudfront.net/assets/img/saturation-fingerprint.png')}


### PR DESCRIPTION
Consistent with prepending behavior prior to #35. Which even removes all depths of relative segments, regardless if it resolves to a valid asset. Perhaps that was never intentional, but nobody's complained.

Fixes #36.