### PR TITLE
Allow for query parameters to be present after URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,13 +96,14 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
    * /([.*+?^=!:${}()|\[\]\/\\])/g - Replace .*+?^=!:${}()|[]/\ in filenames with an escaped version for an exact name match
    * [^"\'\\(\\)\\\\>=]* - Do not match any of ^"'()\>= 0 or more times - Explicitly add \ here because of handlebars compilation
    * ) - End first pattern match
+   * (\\?[^"\'\\)> ]*)? - Allow for query parameters to be present after the URL of an asset
    * \\s* - Any amount of white space
    * [\\\\]* - Allow any amount of \ - For handlebars compilation (includes \\\)
    * \\s* - Any amount of white space
    * ["\'\\)> ]{1} - Match one of "'( > exactly one time
    */
 
-  var re = new RegExp('["\'\\(=]{1}\\s*([^"\'\\(\\)=]*' + escapeRegExp(assetPath) + '[^"\'\\(\\)\\\\>=]*)\\s*[\\\\]*\\s*["\'\\)> ]{1}', 'g');
+  var re = new RegExp('["\'\\(=]{1}\\s*([^"\'\\(\\)=]*' + escapeRegExp(assetPath) + '[^"\'\\(\\)\\\\>=]*)(\\?[^"\'\\)> ]*)?\\s*[\\\\]*\\s*["\'\\)> ]{1}', 'g');
   var match = null;
   /*
    * This is to ignore matches that should not be changed

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -203,4 +203,19 @@ describe('broccoli-asset-rev', function() {
       confirmOutput(graph.directory, sourcePath + '/output');
     });
   });
+
+  it('handles URLs with query parameters in them', function () {
+    var sourcePath = 'tests/fixtures/query-strings';
+    var node = new AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        'foo/bar/widget.js': 'foo/bar/fingerprinted-widget.js',
+        'script-tag-with-query-parameters.html': 'script-tag-with-query-parameters.html',
+      },
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
 });

--- a/tests/fixtures/query-strings/input/script-tag-with-query-parameters.html
+++ b/tests/fixtures/query-strings/input/script-tag-with-query-parameters.html
@@ -1,0 +1,4 @@
+<script src="foo/bar/widget.js?hello=world"></script>
+<script src="foo/bar/widget.js?hello=world&amp;foo=bar"></script>
+<script src=foo/bar/widget.js?hello=world></script>
+<script src=foo/bar/widget.js?hello=world async></script>

--- a/tests/fixtures/query-strings/output/script-tag-with-query-parameters.html
+++ b/tests/fixtures/query-strings/output/script-tag-with-query-parameters.html
@@ -1,0 +1,4 @@
+<script src="foo/bar/fingerprinted-widget.js?hello=world"></script>
+<script src="foo/bar/fingerprinted-widget.js?hello=world&amp;foo=bar"></script>
+<script src=foo/bar/fingerprinted-widget.js?hello=world></script>
+<script src=foo/bar/fingerprinted-widget.js?hello=world async></script>


### PR DESCRIPTION
I'm doing some ember-cli development and I'm integrating some 3rd party code. It has stuff like:
```html
<script src="something.js?v=1">
```

... not the prettiest thing, but the team is hesitant of maintaining a fork of the code. Although it is not pretty, it is a valid case, nevertheless. So I was thinking of something along the lines of the included commit.

Is this approach reasonable and are there any other cases I should be handling within the regex?

P. S. The relevant ember-cli issue is https://github.com/ember-cli/ember-cli/issues/6040