### PR TITLE
Support rewriting multiple references to the same asset path

### DIFF
--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -203,4 +203,19 @@ describe('broccoli-asset-rev', function() {
       confirmOutput(graph.directory, sourcePath + '/output');
     });
   });
+
+  it('handles multiple references to the same url', function () {
+    var sourcePath = 'tests/fixtures/multiple-urls-prepend';
+    var node = new AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        'images/defs.svg': 'assets/images/defs.svg'
+      },
+      prepend: 'https://cloudfront.net/'
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
 });

--- a/tests/fixtures/multiple-urls-prepend/input/unquoted-url-in-styles.css
+++ b/tests/fixtures/multiple-urls-prepend/input/unquoted-url-in-styles.css
@@ -1,0 +1,4 @@
+.sample-img-small   { width:  50px; height:  50px; background-image:url(/images/defs.svg#smallish) }
+.sample-img-medium  { width:  80px; height:  80px; background-image:url(/images/defs.svg#smallish) }
+.sample-img-large   { width: 120px; height: 120px; background-image:url(/images/defs.svg#largish) }
+.sample-img-xlarge  { width: 240px; height: 240px; background-image:url(/images/defs.svg#largish) }

--- a/tests/fixtures/multiple-urls-prepend/output/unquoted-url-in-styles.css
+++ b/tests/fixtures/multiple-urls-prepend/output/unquoted-url-in-styles.css
@@ -1,0 +1,4 @@
+.sample-img-small   { width:  50px; height:  50px; background-image:url(https://cloudfront.net/assets/images/defs.svg#smallish) }
+.sample-img-medium  { width:  80px; height:  80px; background-image:url(https://cloudfront.net/assets/images/defs.svg#smallish) }
+.sample-img-large   { width: 120px; height: 120px; background-image:url(https://cloudfront.net/assets/images/defs.svg#largish) }
+.sample-img-xlarge  { width: 240px; height: 240px; background-image:url(https://cloudfront.net/assets/images/defs.svg#largish) }


### PR DESCRIPTION
Fixes #39. Basically, we don't want to rewrite `assetPath` if the string already contains `replacementPath`. We still do the prepend if it exists, though. Also cleaned up the `assetPath` regex matcher a little.