### PR TITLE
Fix simple errors in regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,21 +89,20 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
    *
    * Uses a regular expression to find assets in html tags, css backgrounds, handlebars pre-compiled templates, etc.
    *
-   * ["\'\\(=]{1} - Match one of "'(= exactly one time
+   * ["\'(=] - Match one of "'(= exactly one time
    * \\s* - Any amount of white space
    * ( - Starts the first pattern match
-   * [^"\'\\(\\)=]* - Do not match any of ^"'()= 0 or more times
-   * /([.*+?^=!:${}()|\[\]\/\\])/g - Replace .*+?^=!:${}()|[]/\ in filenames with an escaped version for an exact name match
-   * [^"\'\\(\\)\\\\>=]* - Do not match any of ^"'()\>= 0 or more times - Explicitly add \ here because of handlebars compilation
+   * [^"\'()=]* - Do not match any of ^"'()= 0 or more times
+   * [^"\'()\\>=]* - Do not match any of ^"'()\>= 0 or more times - Explicitly add \ here because of handlebars compilation
    * ) - End first pattern match
-   * (\\?[^"\'\\)> ]*)? - Allow for query parameters to be present after the URL of an asset
+   * (\\?[^"\')> ]*)? - Allow for query parameters to be present after the URL of an asset
    * \\s* - Any amount of white space
-   * [\\\\]* - Allow any amount of \ - For handlebars compilation (includes \\\)
+   * \\\\* - Allow any amount of \ - For handlebars compilation (includes \\\)
    * \\s* - Any amount of white space
-   * ["\'\\)> ]{1} - Match one of "'( > exactly one time
+   * ["\')> ] - Match one of "'( > exactly one time
    */
 
-  var re = new RegExp('["\'\\(=]{1}\\s*([^"\'\\(\\)=]*' + escapeRegExp(assetPath) + '[^"\'\\(\\)\\\\>=]*)(\\?[^"\'\\)> ]*)?\\s*[\\\\]*\\s*["\'\\)> ]{1}', 'g');
+  var re = new RegExp('["\'(=]\\s*([^"\'()=]*' + escapeRegExp(assetPath) + '[^"\'()\\>=]*)(\\?[^"\')> ]*)?\\s*\\\\*\\s*["\')> ]', 'g');
   var match = null;
   /*
    * This is to ignore matches that should not be changed
@@ -185,6 +184,9 @@ AssetRewrite.prototype.generateAssetMapKeys = function () {
   this.assetMapKeys = keys;
 };
 
+/*
+ * /([.*+?^=!:${}()|\[\]\/\\])/g - Replace .*+?^=!:${}()|[]/\ in filenames with an escaped version for an exact name match
+ */
 function escapeRegExp(string) {
   return string.replace(/([.*+?^${}()|\[\]\/\\])/g, "\\$1");
 }


### PR DESCRIPTION
- remove backslash from character classes where it was unintentionally included (per comments)
- remove unnecessary character class defined for a single character
- remove {1} because it has no effect