### PR TITLE
Make a failing regexp work with multiline inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
     replaceString = match[1].replace(assetPath, replacementPath);
 
     if (this.prepend && replaceString.indexOf(this.prepend) !== 0) {
-      var removeLeadingRelativeOrSlashRegex = new RegExp('^(\\.*/)*(.*)$');
+      var removeLeadingRelativeOrSlashRegex = new RegExp('^(\\.*/)*(.*)$', 'm');
       replaceString = this.prepend + removeLeadingRelativeOrSlashRegex.exec(replaceString)[2];
     }
 


### PR DESCRIPTION
This is probably not helpful but I want to highlight the potential fix here in case anyone else runs into this issue.

https://github.com/rickharrison/broccoli-asset-rewrite/issues/42#issuecomment-253570046

My intuition is that this is actually a bug with `broccoli-asset-rev` because this code ends up being called with a multiline input.

I don't know much about the background, I only know that this issue is blocking my team and that this fix is working right now :-)

Happy to help try to debug the issue.