### PR TITLE
failing test for css/js source maps

### DIFF
--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -130,9 +130,11 @@ describe('broccoli-asset-rev', function() {
     var sourcePath = 'tests/fixtures/sourcemaps';
 
     var node = new AssetRewrite(sourcePath + '/input', {
-      replaceExtensions: ['js'],
+      replaceExtensions: ['js', 'css'],
       assetMap: {
         'the.map' : 'the-other-map',
+        'styles.css' : 'styles-fp1.css',
+        'styles.css.map' : 'styles.css-fp2.map',
         'http://absolute.com/source.map' : 'http://cdn.absolute.com/other-map'
       }
     });

--- a/tests/fixtures/sourcemaps/input/styles.css
+++ b/tests/fixtures/sourcemaps/input/styles.css
@@ -1,0 +1,12 @@
+.sample-img {
+  width: 50px;
+  height: 50px;
+  background-image: url(images/sample.png);
+}
+
+.sample-img2 {
+  width: 50px;
+  height: 50px;
+  background-image: url('images/sample.png');
+}
+/*# sourceMappingURL=styles.css.map */

--- a/tests/fixtures/sourcemaps/output/styles.css
+++ b/tests/fixtures/sourcemaps/output/styles.css
@@ -1,0 +1,12 @@
+.sample-img {
+  width: 50px;
+  height: 50px;
+  background-image: url(images/sample.png);
+}
+
+.sample-img2 {
+  width: 50px;
+  height: 50px;
+  background-image: url('images/sample.png');
+}
+/*# sourceMappingURL=styles.css-fp2.map */


### PR DESCRIPTION
@rickharrison, I took a few minutes yesterday to take a peek at a fix for the css sourcemap issue when the sourcemap name contains the css name.  (application.css => application.css.map)

I am thinking that the best place to fix it is in this project, and here are some broken tests.  When I get some time, I will dig into the rewrite strategy for this case.