### PR TITLE
Add failing tests for fingerprinting srcset

### DIFF
--- a/tests/fixtures/absolute-prepend/input/img-tag.html
+++ b/tests/fixtures/absolute-prepend/input/img-tag.html
@@ -1,1 +1,1 @@
-<img src="/my-image.png">
+<img src="/images/my-folder/my-image.png" srcset="/images/my-folder/my-image.png 1x, /images/my-folder/my-image_@2x.png 2x" />

--- a/tests/fixtures/absolute-prepend/output/img-tag.html
+++ b/tests/fixtures/absolute-prepend/output/img-tag.html
@@ -1,1 +1,1 @@
-<img src="https://cloudfront.net/my-image-fingerprinted.png">
+<img src="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png" srcset="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png 1x, https://cloudfront.net/images/my-folder/my-image-fingerprinted_@2.png 2x" />


### PR DESCRIPTION
Fingerprinting srcset is not working.

### Expected:
```html
<img src="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png" srcset="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png 1x, https://cloudfront.net/images/my-folder/my-image-fingerprinted_@2.png 2x" />
```

### Actual:
```html
<img src="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png" srcset="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png 1x, /images/my-folder/my-image_@2x.png 2x" />
```

<img width="1750" alt="screen shot 2017-01-03 at 12 52 59" src="https://cloud.githubusercontent.com/assets/7160913/21608542/10817ebc-d1b5-11e6-9050-54e8abbff433.png">
