### PR TITLE
Fix repeat images issue

### DIFF
--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -52,7 +52,7 @@ describe('broccoli-asset-rev', function() {
     return builder.build().then(function(graph) {
       confirmOutput(graph.directory, sourcePath + '/output');
     });
-  })
+  });
 
   it('ignore option tell filter what files should not be processed', function(){
     var sourcePath = 'tests/fixtures/with-ignore';
@@ -231,6 +231,22 @@ describe('broccoli-asset-rev', function() {
     builder = new broccoli.Builder(node);
     return builder.build().then(function (graph) {
       confirmOutput(graph.directory, sourcePath + '/output');
-    })
+    });
   });
+
+  it('rewrites multiple references to the same url', function () {
+    var sourcePath = 'tests/fixtures/repeated-url-prepend';
+    var node = new AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        'assets/images/repeated.png': 'assets/images/repeated.png'
+      },
+      prepend: 'https://cloudfront.net/'
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
+
 });

--- a/tests/fixtures/repeated-url-prepend/input/assets/url-in-styles.css
+++ b/tests/fixtures/repeated-url-prepend/input/assets/url-in-styles.css
@@ -1,0 +1,17 @@
+.sample-img{
+  width: 50px;
+  height: 50px;
+  background-image: url('images/repeated.png');
+}
+
+.sample-img2{
+  width: 50px;
+  height: 50px;
+  background-image: url('images/repeated.png');
+}
+
+.sample-img3{
+  width: 50px;
+  height: 50px;
+  background-image: url('images/repeated.png');
+}

--- a/tests/fixtures/repeated-url-prepend/output/assets/url-in-styles.css
+++ b/tests/fixtures/repeated-url-prepend/output/assets/url-in-styles.css
@@ -1,0 +1,17 @@
+.sample-img{
+  width: 50px;
+  height: 50px;
+  background-image: url('https://cloudfront.net/assets/images/repeated.png');
+}
+
+.sample-img2{
+  width: 50px;
+  height: 50px;
+  background-image: url('https://cloudfront.net/assets/images/repeated.png');
+}
+
+.sample-img3{
+  width: 50px;
+  height: 50px;
+  background-image: url('https://cloudfront.net/assets/images/repeated.png');
+}


### PR DESCRIPTION
This is to fix the issue mentioned here: https://github.com/rickharrison/broccoli-asset-rewrite/pull/47

NB: this also reverted replaceString to original version by
supporting fragments, the reason is we want to support something like
this:

assetPath: /devassets/foo.jpg
should rewrite to: //cloudfront.net/assets/foo-fingerprinted.jpg
