### PR TITLE
rewrite asset paths inside srcset lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,20 +93,20 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
    *
    * Uses a regular expression to find assets in html tags, css backgrounds, handlebars pre-compiled templates, etc.
    *
-   * ["\'(=] - Match one of "'(= exactly one time
+   * ["\'(=,] - Match one of "'(=, exactly one time - the comma matches the end of the previous path inside a srcset
    * \\s* - Any amount of white space
    * ( - Starts the first capture group
-   * [^"\'()=]* - Do not match any of ^"'()= 0 or more times
-   * [^"\'()\\>=]* - Do not match any of ^"'()\>= 0 or more times - Explicitly add \ here because of handlebars compilation
+   * [^"\'()=,]* - Do not match any of ^"'()=, 0 or more times
+   * [^"\'()\\>=,]* - Do not match any of ^"'()\>= 0 or more times - Explicitly add \ here because of handlebars compilation
    * ) - End first capture group
    * (\\?[^"\')> ]*)? - Allow for query parameters to be present after the URL of an asset
    * \\s* - Any amount of white space
    * \\\\* - Allow any amount of \ - For handlebars compilation (includes \\\)
    * \\s* - Any amount of white space
-   * ["\')> ] - Match one of "'( > exactly one time
+   * ["\')> ,] - Match one of "'( >, exactly one time
    */
 
-  var re = new RegExp('["\'(=]\\s*([^"\'()=]*' + escapeRegExp(assetPath) + '[^"\'()\\>=]*)(\\?[^"\')> ]*)?\\s*\\\\*\\s*["\')> ]', 'g');
+  var re = new RegExp('["\'(=,]\\s*([^"\'()=,]*' + escapeRegExp(assetPath) + '[^"\'()\\>=,]*)(\\?[^"\')> ]*)?\\s*\\\\*\\s*["\')> ,]', 'g');
   var match = null;
   /*
    * This is to ignore matches that should not be changed

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -233,4 +233,22 @@ describe('broccoli-asset-rev', function() {
       confirmOutput(graph.directory, sourcePath + '/output');
     })
   });
+
+  it('handles srcset', function () {
+    var sourcePath = 'tests/fixtures/srcset';
+    debugger
+    var node = new AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        '/images/my-folder/my-image.png': '/images/my-folder/my-image-fingerprinted.png',
+        '/images/my-folder/my-image_@1.5x.png': '/images/my-folder/my-image-fingerprinted_@1.5x.png',
+        '/images/my-folder/my-image_@150w.png': '/images/my-folder/my-image-fingerprinted_@150w.png'
+      },
+      prepend: 'https://cloudfront.net/'
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
 });

--- a/tests/fixtures/srcset/input/img-tag.html
+++ b/tests/fixtures/srcset/input/img-tag.html
@@ -1,0 +1,4 @@
+<img src="/images/my-folder/my-image.png" srcset="/images/my-folder/my-image.png 1x, /images/my-folder/my-image_@1.5x.png 1.5x" />
+<img src="/images/my-folder/my-image.png" srcset="/images/my-folder/my-image.png 100w, /images/my-folder/my-image_@150w.png 150w" />
+<img src="/images/my-folder/my-image.png" srcset="/images/my-folder/my-image.png1x, /images/my-folder/my-image_@1.5x.png1.5x" />
+<img src="/images/my-folder/my-image.png" srcset="/images/my-folder/my-image.png100w, /images/my-folder/my-image_@150w.png150w" />

--- a/tests/fixtures/srcset/output/img-tag.html
+++ b/tests/fixtures/srcset/output/img-tag.html
@@ -1,0 +1,4 @@
+<img src="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png" srcset="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png 1x, https://cloudfront.net/images/my-folder/my-image-fingerprinted_@1.5x.png 1.5x" />
+<img src="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png" srcset="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png 100w, https://cloudfront.net/images/my-folder/my-image-fingerprinted_@150w.png 150w" />
+<img src="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png" srcset="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png1x, https://cloudfront.net/images/my-folder/my-image-fingerprinted_@1.5x.png1.5x" />
+<img src="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png" srcset="https://cloudfront.net/images/my-folder/my-image-fingerprinted.png100w, https://cloudfront.net/images/my-folder/my-image-fingerprinted_@150w.png150w" />


### PR DESCRIPTION
Fixes rickharrison/broccoli-asset-rewrite#51

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img), the srcset attribute contains:

> A list of *one or more strings separated by commas* indicating a set of possible image sources for the user agent to use. Each string is composed of:
> 1. a URL to an image,
> 1. optionally, whitespace followed by one of:
>   - a width descriptor, or a positive integer directly followed by 'w'. 
>   - a pixel density descriptor, which is a positive floating point number directly followed by 'x'.

The `rewriteAssetPath` logic seems to behave properly if we simply allow assetPaths to begin/end with commas (in addition to quotes, open paren, and equals). The match will include the width/pixel-density descriptor at the end, but that does not appear to cause problems (in the admittedly few cases that I've tested).