### PR TITLE
README: Repair Markdown heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#broccoli-asset-rewrite
+# broccoli-asset-rewrite
 
 [![CircleCI](https://img.shields.io/circleci/project/rickharrison/broccoli-asset-rewrite.svg)](https://circleci.com/gh/rickharrison/broccoli-asset-rewrite)
 [![codecov.io](https://codecov.io/github/rickharrison/broccoli-asset-rewrite/coverage.svg?branch=master&precision=2)](https://codecov.io/github/rickharrison/broccoli-asset-rewrite?branch=master)


### PR DESCRIPTION
This PR fixes rendering of the heading on GitHub.