### PR TITLE
Fix prepend option in srcset attributes

### DIFF
--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -233,4 +233,37 @@ describe('broccoli-asset-rev', function() {
       confirmOutput(graph.directory, sourcePath + '/output');
     })
   });
+
+  it('replaces assets in srcset attributes', function(){
+    var sourcePath = 'tests/fixtures/srcset';
+    var node = AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        '/assets/img/small.png': '/assets/img/other-small.png',
+        '/assets/img/medium.png': '/assets/img/other-medium.png',
+        '/assets/img/big.png': '/assets/img/other-big.png'
+      }
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
+
+  it('replaces assets in srcset attributes with prepend option', function(){
+    var sourcePath = 'tests/fixtures/srcset-prepend';
+    var node = AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        '/assets/img/small.png': '/assets/img/other-small.png',
+        '/assets/img/medium.png': '/assets/img/other-medium.png',
+        '/assets/img/big.png': '/assets/img/other-big.png'
+      },
+      prepend: 'https://subdomain.cloudfront.net/'
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
 });

--- a/tests/fixtures/srcset-prepend/input/img.html
+++ b/tests/fixtures/srcset-prepend/input/img.html
@@ -1,0 +1,2 @@
+<img src="/assets/img/small.png"
+     srcset="/assets/img/medium.png 2x, /assets/img/big.png 3x">

--- a/tests/fixtures/srcset-prepend/output/img.html
+++ b/tests/fixtures/srcset-prepend/output/img.html
@@ -1,0 +1,2 @@
+<img src="https://subdomain.cloudfront.net/assets/img/other-small.png"
+     srcset="https://subdomain.cloudfront.net/assets/img/other-medium.png 2x, https://subdomain.cloudfront.net/assets/img/other-big.png 3x">

--- a/tests/fixtures/srcset/input/img.html
+++ b/tests/fixtures/srcset/input/img.html
@@ -1,0 +1,2 @@
+<img src="/assets/img/small.png"
+     srcset="/assets/img/medium.png 2x, /assets/img/big.png 3x, /assets/img/big.png 4x">

--- a/tests/fixtures/srcset/output/img.html
+++ b/tests/fixtures/srcset/output/img.html
@@ -1,0 +1,2 @@
+<img src="/assets/img/other-small.png"
+     srcset="/assets/img/other-medium.png 2x, /assets/img/other-big.png 3x, /assets/img/other-big.png 4x">


### PR DESCRIPTION
The problem in rickharrison/broccoli-asset-rev#48 happened because
the logic to avoid prepending assets twice did not take into account
the edge case of srcset, where there are many assets in one match.

This edge case complicates things more than a bit. To simplify the
solution, when a prepend option is found, we use a replacer function
as second parameter.

Closes rickharrison/broccoli-asset-rev#48
Closes #51