### PR TITLE
Handle sourcemaps when publicUrl is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
   }
 
   var self = this;
-  return newString.replace(new RegExp('sourceMappingURL=' + escapeRegExp(assetPath)), function(wholeMatch) {
+  return newString.replace(new RegExp('sourceMappingURL=\\S*' + escapeRegExp(assetPath)), function(wholeMatch) {
     var replaceString = replacementPath;
     if (self.prepend && (!/^sourceMappingURL=(http|https|\/\/)/.test(wholeMatch))) {
       replaceString = self.prepend + replacementPath;

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -159,6 +159,22 @@ describe('broccoli-asset-rev', function() {
     });
   });
 
+  it('replaces source map URLs when publicUrl is used', function () {
+    var sourcePath = 'tests/fixtures/sourcemaps-publicUrl';
+
+    var node = new AssetRewrite(sourcePath + '/input', {
+      replaceExtensions: ['js'],
+      assetMap: {
+        'the.map' : 'the-other-map',
+        'source.map' : 'other-map'
+      }
+    });
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
+
   it('maintains fragments', function () {
     var sourcePath = 'tests/fixtures/fragments';
     var node = new AssetRewrite(sourcePath + '/input', {

--- a/tests/fixtures/sourcemaps-publicUrl/input/abs.js
+++ b/tests/fixtures/sourcemaps-publicUrl/input/abs.js
@@ -1,0 +1,1 @@
+(function x(){return 42})//# sourceMappingURL=https://my.public.url/source.map

--- a/tests/fixtures/sourcemaps-publicUrl/input/sample.js
+++ b/tests/fixtures/sourcemaps-publicUrl/input/sample.js
@@ -1,0 +1,1 @@
+(function x(){return 42})//# sourceMappingURL=http://publicUrl/the.map

--- a/tests/fixtures/sourcemaps-publicUrl/output/abs.js
+++ b/tests/fixtures/sourcemaps-publicUrl/output/abs.js
@@ -1,0 +1,1 @@
+(function x(){return 42})//# sourceMappingURL=https://my.public.url/other-map

--- a/tests/fixtures/sourcemaps-publicUrl/output/sample.js
+++ b/tests/fixtures/sourcemaps-publicUrl/output/sample.js
@@ -1,0 +1,1 @@
+(function x(){return 42})//# sourceMappingURL=http://publicUrl/the-other-map


### PR DESCRIPTION
I recently introduced [a change](https://github.com/ember-cli/broccoli-uglify-sourcemap/pull/126/files) in broccoli-uglify-sourcemap that allows specifying a `publicUrl` in sourcemaps. However, since the [regex used](https://github.com/rickharrison/broccoli-asset-rewrite/blob/master/index.js#L135) only checks for `sourceMappingUrl=` followed by the name of the sourcemap itself, it will not get fingerprinted.