### PR TITLE
Add failing spec, using relative and absolute path to same asset fails

### DIFF
--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -249,4 +249,20 @@ describe('broccoli-asset-rev', function() {
       confirmOutput(graph.directory, sourcePath + '/output');
     });
   });
+
+  it('should prepend both relative and abosulte paths to the same asset', function(){
+    var sourcePath = 'tests/fixtures/mixed-relative-absolute-urls-prepend';
+    var node = AssetRewrite(sourcePath + '/input', {
+      assetMap: {
+        'assets/images/some-image.svg': 'assets/images/some-image-fingerprinted.svg'
+      },
+      replaceExtensions: ['js'],
+      prepend: 'https://cloudfront.net/'
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  })
 });

--- a/tests/fixtures/mixed-relative-absolute-urls-prepend/input/test.js
+++ b/tests/fixtures/mixed-relative-absolute-urls-prepend/input/test.js
@@ -1,0 +1,2 @@
+let relativePath = "assets/images/some-image.svg";
+let absolutePath = "/assets/images/some-image.svg";

--- a/tests/fixtures/mixed-relative-absolute-urls-prepend/output/test.js
+++ b/tests/fixtures/mixed-relative-absolute-urls-prepend/output/test.js
@@ -1,0 +1,2 @@
+let src1 = "https://cloudfront.net/assets/images/some-image-fingerprinted.svg";
+let src2 = "https://cloudfront.net/assets/images/some-image-fingerprinted.svg";


### PR DESCRIPTION
Add failing spec for situation where using relative and absolute path for the same asset, generates an invalid url. An extra '/' is added in front of the prepended url for the absolute path.

So when you have a js file like this:

```
let relativePath = "assets/images/some-image.svg";
let absolutePath = "/assets/images/some-image.svg";
```
it generates this:
```
let relativePath = "https://cloudfront.net/assets/images/some-image-fingerprinted.svg";
let absolutePath = "/https://cloudfront.net/assets/images/some-image-fingerprinted.svg";
```

I could not find the code which is causing this unexpected behaviour, but i managed to write a failing spec. Hopefully someone else is able to fix this.