### PR TITLE
Add support for replacing in backticks strings in JS

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,20 +93,20 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
    *
    * Uses a regular expression to find assets in html tags, css backgrounds, handlebars pre-compiled templates, etc.
    *
-   * ["\'(=] - Match one of "'(= exactly one time
+   * (["'`(=]|`\$\{[^\}\n]+\}) -  Match one of "'`(= exactly one time, or match string interpolation in a backtick string
    * \\s* - Any amount of white space
    * ( - Starts the first capture group
-   * [^"\'()=]* - Do not match any of ^"'()= 0 or more times
-   * [^"\n\'()\\>=]* - Do not match any of ^"\n'()\>= 0 or more times - Explicitly add \ here because of handlebars compilation
+   * [^"\'`()=]* - Do not match any of ^"'`()= 0 or more times
+   * [^"\n\'`()\\>=]* - Do not match any of ^"\n'`()\>= 0 or more times - Explicitly add \ here because of handlebars compilation
    * ) - End first capture group
-   * (\\?[^"\')> ]*)? - Allow for query parameters to be present after the URL of an asset
+   * (\\?[^"\'`)> ]*)? - Allow for query parameters to be present after the URL of an asset
    * \\s* - Any amount of white space
    * \\\\* - Allow any amount of \ - For handlebars compilation (includes \\\)
    * \\s* - Any amount of white space
-   * ["\')>\s] - Match one of "'(\n> exactly one time
+   * ["\'`)>\s] - Match one of "'`)\n> exactly one time
    */
 
-  var re = new RegExp('["\'(=]\\s*([^"\'()=]*' + escapeRegExp(assetPath) + '[^"\n\'()\\>=]*)(\\?[^"\')> ]*)?\\s*\\\\*\\s*["\')>\s]', 'g');
+  var re = new RegExp('(?:["\'`(=]|`\\$\\{[^\\}\\n]+\\})\\s*([^"\'`()=]*' + escapeRegExp(assetPath) + '[^"\n\'`()\\>=]*)(\\?[^"\'`)> ]*)?\\s*\\\\*\\s*["\'`)>\s]', 'g');
   var match = null;
   
   /*

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -34,6 +34,7 @@ describe('broccoli-asset-rev', function() {
   it('uses the provided assetMap to replace strings', function(){
     var sourcePath = 'tests/fixtures/basic';
     var node = AssetRewrite(sourcePath + '/input', {
+      replaceExtensions: ["html", "css", "js"],
       assetMap: {
         'foo/bar/widget.js': 'blahzorz-1.js',
         'images/sample.png': 'images/fingerprinted-sample.png',

--- a/tests/fixtures/basic/input/backtick-strings-in-object-literal.js
+++ b/tests/fixtures/basic/input/backtick-strings-in-object-literal.js
@@ -1,0 +1,9 @@
+var a = {
+  b: {
+    backticksOnly: `/images/sample.png`,
+    interpolationWithProperty: `${this.config.baseUrl}/images/sample.png`,
+    interpolationWithMethodCall: `${this.getBaseUrl()}/images/sample.png`,
+    interpolationWithMethodCallSingleQuotes: `${this.get('baseUrl')}/images/sample.png`,
+    interpolationWithMethodCallDoubleQuotes: `${this.get("baseUrl")}/images/sample.png`
+  }
+};

--- a/tests/fixtures/basic/output/backtick-strings-in-object-literal.js
+++ b/tests/fixtures/basic/output/backtick-strings-in-object-literal.js
@@ -1,0 +1,9 @@
+var a = {
+  b: {
+    backticksOnly: `/images/fingerprinted-sample.png`,
+    interpolationWithProperty: `${this.config.baseUrl}/images/fingerprinted-sample.png`,
+    interpolationWithMethodCall: `${this.getBaseUrl()}/images/fingerprinted-sample.png`,
+    interpolationWithMethodCallSingleQuotes: `${this.get('baseUrl')}/images/fingerprinted-sample.png`,
+    interpolationWithMethodCallDoubleQuotes: `${this.get("baseUrl")}/images/fingerprinted-sample.png`
+  }
+};


### PR DESCRIPTION
This PR adds support for rewriting asset paths in Javascript template literals (a.k.a backtick strings). This includes some† support for string interpolation. It is intended to address the issue reported here: https://github.com/rickharrison/broccoli-asset-rewrite/issues/66

† I've added support for what seemed like the most common cases of string interpolation: variables and property access, method calls, method calls with strings, array index access. As far as I know any valid JS expressions could go in a string interpolation, so that could include arrow functions and other complicated structures. The updated regex section accepts any characters except the closing brace `}` so potentially it might not match on a line with a complicated string interpolation.